### PR TITLE
AutoFocus `primary` buttons, to allow faster modal dismissal

### DIFF
--- a/src/components/modules/button/Button.tsx
+++ b/src/components/modules/button/Button.tsx
@@ -6,11 +6,13 @@ interface ButtonProps {
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   primary?: boolean;
   disabled?: boolean;
+  autoFocus?: boolean;
 }
 export const Button = ({
   children,
   primary = false,
   disabled = false,
+  autoFocus = false,
   onClick
 }: PropsWithChildren<ButtonProps>) => {
   return (
@@ -20,6 +22,7 @@ export const Button = ({
         [styles.green]: primary,
         [styles.disabled]: disabled
       })}
+      autoFocus={autoFocus}
     >
       {children}
     </button>

--- a/src/components/shared/modal/ConfirmButtons.tsx
+++ b/src/components/shared/modal/ConfirmButtons.tsx
@@ -9,7 +9,7 @@ export const ConfirmButtons = ({
   return (
     <div className={styles.root}>
       <Button onClick={onCancel}>No</Button>
-      <Button primary onClick={onConfirm}>Yes</Button>
+      <Button primary onClick={onConfirm} autoFocus>Yes</Button>
     </div>
   )
 }


### PR DESCRIPTION
Sets the autofocus property on a button if the button is primary.

End result is you can `Enter` out of modals

## Technical Changes
Sets the `autoFocus` property on buttons if `primary` is true, which react then uses to focus the button upon mount.

## End-user Changelog
```
Modal dialogs can be dismissed by pressing `Enter`
```
